### PR TITLE
[TEST] validate Kestra 2.x compat job (do not merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ permissions:
 
 jobs:
   check:
-    uses: kestra-io/actions/.github/workflows/plugins.yml@main
+    uses: kestra-io/actions/.github/workflows/plugins.yml@feat/plugins-compat-compile-check
     with:
       skip-test: ${{ github.event.inputs.skip-test == 'true' }}
       kestra-version: ${{ github.event.inputs.kestra-version }}


### PR DESCRIPTION
Temporary test PR to exercise the new compat-kestra-2x job from kestra-io/actions#176. Pins the reusable workflow to that branch. Do not merge; will be closed after validation.